### PR TITLE
Fix: Usage of context during event callbacks

### DIFF
--- a/event/event.js
+++ b/event/event.js
@@ -153,31 +153,18 @@ SOFTWARE.
 
         var x,
           callback,
-          ctx,
-          callWithContext;
-
-        // This special scope is used to ensure that function executed
-        // asynchronously are done so with the appropriate context.
-        callWithContext = function (fn, ctx) {
-
-          return function () {
-
-            fn.call(ctx);
-
-          };
-
-        };
+          ctx;
 
         this.events[event] = this.events[event] || [];
 
         for (x = 0; x < this.events[event].length; x = x + 1) {
 
           callback = this.events[event][x].callback;
-          ctx = this.events[event][x].ctx;
+          ctx = this.events[event][x].context;
 
           if (typeof callback === "function") {
 
-            defer(callWithContext(callback, ctx));
+            defer(defer.bind(callback, ctx));
 
           }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Kevin Conway <kevinjacobconway@gmail.com> (https://github.com/kevinconway)",
   "name": "eventjs",
   "description": "Cross platform, asynchronous events for JavaScript.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/kevinconway/Event.js",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "modelo": "3.x.x",
-    "deferjs": "2.x.x"
+    "deferjs": ">=2.1.x <3.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/test/event.spec.js
+++ b/test/event.spec.js
@@ -45,6 +45,25 @@
 
         });
 
+        it('executes callbacks in the correct context', function (done) {
+
+          var t = new EventMixin(),
+            test_value = {};
+
+          t.on('test', function () {
+            this.test = true;
+            expect(test_value.test).to.be(true);
+            done();
+          }, test_value);
+
+          expect(test_value.test).to.be(undefined);
+
+          t.trigger('test');
+
+          expect(test_value.test).to.be(undefined);
+
+        });
+
         it('removes events', function (done) {
 
           var t = new EventMixin(),


### PR DESCRIPTION
Replaced one-off method with new method from defer.js to bind
the context to the callback. Also, the trigger function was
trying to access the wrong variable (ctx vs context) when pulling
the execution context out of the event map.

Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
