### PR TITLE
Fix bug causing emit to alway pass undefined arg

### DIFF
--- a/event/event.js
+++ b/event/event.js
@@ -188,7 +188,7 @@ module.exports = (function () {
       remove = [];
 
     for (x = 1; x < length; x = x + 1) {
-      listenerArgs[x] = arguments[x];
+      listenerArgs[x - 1] = arguments[x];
     }
 
     this.events[event] = this.events[event] || [];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Kevin Conway <kevinjacobconway@gmail.com> (https://github.com/kevinconway)",
   "name": "eventjs",
   "description": "Cross platform, asynchronous EventEmitter.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "homepage": "https://github.com/kevinconway/Event.js",
   "repository": {
     "type": "git",

--- a/test/event.spec.js
+++ b/test/event.spec.js
@@ -213,6 +213,21 @@ describe('Event.js', function () {
 
     });
 
+    it('passes arguments to the listeners', function (done) {
+
+      var e = new EventMixin();
+
+      e.once('test', function (a, b, c) {
+        expect(a).to.be(true);
+        expect(b).to.be(false);
+        expect(c).to.be(null);
+      });
+      e.once('done', function () { done(); });
+      e.emit('test', true, false, null);
+      e.emit('done');
+
+    });
+
   });
 
   describe('The listenerCount method', function () {


### PR DESCRIPTION
Off by one error caused the first argument passed to all listeners
to be undefined. Arguments are now adjusted appropriately.
